### PR TITLE
feature: Add driver logger handler for redirecting logging output

### DIFF
--- a/sdk/python/conveyor/runtime/driver_logger_handler.py
+++ b/sdk/python/conveyor/runtime/driver_logger_handler.py
@@ -1,0 +1,34 @@
+import logging
+import asyncio
+import sys
+
+class DriverLoggerHandler(logging.Handler):
+    def __init__(self, driver_logger):
+        super().__init__()
+        self.driver_logger = driver_logger
+    
+    def emit(self, record):
+        labels = {
+            "level": record.levelname,
+            "module": getattr(record, 'module', 'unknown')
+        }
+        
+        message = record.getMessage()
+        
+        asyncio.create_task(self.driver_logger.log(labels, message))
+
+
+
+class PrintHandler:
+    def __init__(self, driver_logger):
+        self.driver_logger = driver_logger
+        self.original_stdout = sys.stdout
+    
+    def write(self, text):
+        if text.strip():
+            labels = {"level": "INFO", "source": "print"}
+            asyncio.create_task(self.driver_logger.log(labels, text.strip()))
+        return len(text)
+    
+    def flush(self):
+        pass


### PR DESCRIPTION

* `DriverLoggerHandler` a `logging.Handler` that forwards every `logging.*` call to `DriverLogger` via an async background task.
* `PrintHandler`  replaces `sys.stdout` or `sys.stderr`captures any `print()` text and routes it through the same `DriverLogger`.

All output now:

* carries labels (`level`, `module`, `source=print`) plus driver/run‑ID context
* is sent to both Loki and NATS without blocking the event loop
* preserves normal `write()` semantics (`return len(text)`), so existing code keeps working.
